### PR TITLE
Rename charm and jaeger relation and clean up status messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ juju deploy elasticsearch-k8s
 Build and deploy the charm:
 ```
 charmcraft pack
-juju deploy ./jaeger.charm --resource agent-image=jaegertracing/jaeger-agent:1.22 \
-                           --resource collector-image=jaegertracing/jaeger-collector:1.22 \
-                           --resource query-image=jaegertracing/jaeger-query:1.22
+juju deploy ./jaeger-k8s.charm \
+    --resource agent-image=jaegertracing/jaeger-agent:1.22 \
+    --resource collector-image=jaegertracing/jaeger-collector:1.22 \
+    --resource query-image=jaegertracing/jaeger-query:1.22
 ```
 
-Add relation between `jaeger` and `elasticsearch-k8s`:
+Add relation between `jaeger-k8s` and `elasticsearch-k8s`:
 ```
-juju add-relation jaeger elasticsearch-k8s
+juju add-relation jaeger-k8s elasticsearch-k8s
 ```
 
 Relate with a Jaeger client application of your choice. Example charms that support relation with this charm include:
@@ -35,7 +36,7 @@ Relate with a Jaeger client application of your choice. Example charms that supp
 
 Example:
 ```
-juju add-relation jaeger jaeger-hotrod
+juju add-relation jaeger-k8s jaeger-hotrod
 ```
 
 ### Configuration options

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,10 +1,10 @@
 # Copyright 2021 Przemysław Lal
 # See LICENSE file for licensing details.
-name: jaeger
+name: jaeger-k8s
 description: |
-  Charm to operate Jaeger
+  Charm to deploy and operate Jaeger.
 summary: |
-  Charm to operate Jaeger
+  Charm to operate and operate Jaeger.
 
 containers:
   agent:
@@ -20,8 +20,8 @@ requires:
     limit: 1
 
 provides:
-  jaeger:
-    interface: distributed-tracing
+  distributed-tracing:
+    interface: jaeger-ingestion
     optional: true
 
 resources:


### PR DESCRIPTION
* rename relation `jaeger:distributed-tracing` to `distributed-tracing:jaeger-ingestion` (fixes #1)
* use BlockedStatus instead of WaitingStatus when datastore relation is  missing (fixes #2)
* rename charm 'jaeger' to 'jaeger-k8s' (fixes #3)
* don't set ActiveStatus message (fixes #4)